### PR TITLE
a11y reduced motion

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     "plugin:github/typescript"
   ],
   "globals": {
-    "CustomElementElement": "readonly"
+    "CustomElementElement": "readonly",
+    "module": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,6 @@
     "plugin:github/typescript"
   ],
   "globals": {
-    "CustomElementElement": "readonly",
-    "module": true
+    "CustomElementElement": "readonly"
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,24 +31,6 @@ window.matchMedia('(prefers-reduced-motion)').matches === true
 
 If this evaluates to true, any content lines provided will be appended immediately rather than being typed out with a delay.
 
-The data attribute `data-reduced-motion` can be used to override the window media value.
-
-```html
-<typing-effect
-  data-lines='["Welcome to GitHub!", "Let’s begin the adventure"]'
-  data-reduced-motion="true"> <!-- This will NOT animate -->
-  <span data-target="typing-effect.content"></span>
-  <span data-target="typing-effect.cursor">|</span>
-</typing-effect>
-
-<typing-effect
-  data-lines='["Welcome to GitHub!", "Let’s begin the adventure"]'
-  data-reduced-motion="false"> <!-- This WILL animate -->
-  <span data-target="typing-effect.content"></span>
-  <span data-target="typing-effect.cursor">|</span>
-</typing-effect>
-```
-
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/README.md
+++ b/README.md
@@ -23,13 +23,31 @@ import '@github/typing-effect-element'
 
 ## Accessibility
 
-This component detects whether `prefers-reduced-motion` is set on the window
+This component detects whether `prefers-reduced-motion` is set on the window:
 
 ```js
 window.matchMedia('(prefers-reduced-motion)').matches === true
 ```
 
 If this evaluates to true, any content lines provided will be appended immediately rather than being typed out with a delay.
+
+The data attribute `data-reduced-motion` can be used to override the window media value.
+
+```html
+<typing-effect
+  data-lines='["Welcome to GitHub!", "Let’s begin the adventure"]'
+  data-reduced-motion="true"> <!-- This will NOT animate -->
+  <span data-target="typing-effect.content"></span>
+  <span data-target="typing-effect.cursor">|</span>
+</typing-effect>
+
+<typing-effect
+  data-lines='["Welcome to GitHub!", "Let’s begin the adventure"]'
+  data-reduced-motion="false"> <!-- This WILL animate -->
+  <span data-target="typing-effect.content"></span>
+  <span data-target="typing-effect.cursor">|</span>
+</typing-effect>
+```
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A custom element that shows text as if it were being typed
 ## Installation
 
 ```
-npm install @github/typing-effect-element
+$ npm install @github/typing-effect-element
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A custom element that shows text as if it were being typed
 ## Installation
 
 ```
-$ npm install @github/typing-effect-element
+npm install @github/typing-effect-element
 ```
 
 ## Usage
@@ -20,6 +20,16 @@ import '@github/typing-effect-element'
   <span data-target="typing-effect.cursor">|</span>
 </typing-effect>
 ```
+
+## Accessibility
+
+This component detects whether `prefers-reduced-motion` is set on the window
+
+```js
+window.matchMedia('(prefers-reduced-motion)').matches === true
+```
+
+If this evaluates to true, any content lines provided will be appended immediately rather than being typed out with a delay.
 
 ## Browser support
 

--- a/karma.config.cjs
+++ b/karma.config.cjs
@@ -1,4 +1,4 @@
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     frameworks: ['mocha', 'chai'],
     files: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,13 +41,7 @@ class TypingEffectElement extends HTMLElement {
   }
 
   get prefersReducedMotion(): boolean {
-    if (this.getAttribute('data-reduced-motion') === 'false') {
-      return false
-    } else if (this.getAttribute('data-reduced-motion') === 'true') {
-      return true
-    } else {
-      return window.matchMedia('(prefers-reduced-motion)').matches
-    }
+    return window.matchMedia('(prefers-reduced-motion)').matches
   }
 
   get characterDelay(): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,7 @@ const loaded: Promise<unknown> = (function () {
 class TypingEffectElement extends HTMLElement {
   async connectedCallback(): Promise<void> {
     await loaded
-    if (this.content)
-      await typeLines(this.lines, this.content, this.characterDelay, this.lineDelay, this.prefersReducedMotion)
+    if (this.content) await typeLines(this.lines, this.content, this.characterDelay, this.lineDelay)
     if (this.cursor) this.cursor.hidden = true
     this.dispatchEvent(
       new CustomEvent('typing:complete', {
@@ -90,11 +89,10 @@ async function typeLines(
   lines: string[],
   contentElement: HTMLElement,
   characterDelay: number,
-  lineDelay: number,
-  reduceMotion: boolean
+  lineDelay: number
 ): Promise<void> {
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-    if (reduceMotion) {
+    if (characterDelay === 0) {
       contentElement.append(lines[lineIndex])
     } else {
       for (const character of lines[lineIndex].split('')) {
@@ -103,7 +101,7 @@ async function typeLines(
       }
     }
 
-    await wait(lineDelay)
+    if (lineDelay !== 0) await wait(lineDelay)
     if (lineIndex < lines.length - 1) contentElement.append(document.createElement('br'))
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ const loaded: Promise<unknown> = (function () {
 class TypingEffectElement extends HTMLElement {
   async connectedCallback(): Promise<void> {
     await loaded
-    if (this.content) await typeLines(this.lines, this.content, this.characterDelay, this.lineDelay)
+    if (this.content)
+      await typeLines(this.lines, this.content, this.characterDelay, this.lineDelay, this.prefersReducedMotion)
     if (this.cursor) this.cursor.hidden = true
     this.dispatchEvent(
       new CustomEvent('typing:complete', {
@@ -93,12 +94,17 @@ async function typeLines(
   lines: string[],
   contentElement: HTMLElement,
   characterDelay: number,
-  lineDelay: number
+  lineDelay: number,
+  reduceMotion: boolean
 ): Promise<void> {
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-    for (const character of lines[lineIndex].split('')) {
-      await wait(characterDelay)
-      contentElement.innerHTML += character
+    if (reduceMotion) {
+      contentElement.append(lines[lineIndex])
+    } else {
+      for (const character of lines[lineIndex].split('')) {
+        await wait(characterDelay)
+        contentElement.innerHTML += character
+      }
     }
 
     await wait(lineDelay)

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,18 @@ class TypingEffectElement extends HTMLElement {
     }
   }
 
+  get prefersReducedMotion(): boolean {
+    if (this.getAttribute('data-reduced-motion') === 'false') {
+      return false
+    } else {
+      return window.matchMedia('(prefers-reduced-motion)').matches
+    }
+  }
+
   get characterDelay(): number {
+    if (this.prefersReducedMotion) {
+      return 0
+    }
     return Math.max(Math.min(0, Math.floor(Number(this.getAttribute('data-character-delay'))), 2_147_483_647)) || 40
   }
 
@@ -51,6 +62,9 @@ class TypingEffectElement extends HTMLElement {
   }
 
   get lineDelay(): number {
+    if (this.prefersReducedMotion) {
+      return 0
+    }
     return Math.max(Math.min(0, Math.floor(Number(this.getAttribute('data-line-delay'))), 2_147_483_647)) || 40
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ class TypingEffectElement extends HTMLElement {
   get prefersReducedMotion(): boolean {
     if (this.getAttribute('data-reduced-motion') === 'false') {
       return false
+    } else if (this.getAttribute('data-reduced-motion') === 'true') {
+      return true
     } else {
       return window.matchMedia('(prefers-reduced-motion)').matches
     }

--- a/test/test.js
+++ b/test/test.js
@@ -68,9 +68,23 @@ describe('typing-effect', function () {
   })
 
   describe('delay attributes', function () {
+    let realMatchMedia
+    before(() => {
+      realMatchMedia = window.matchMedia
+      window.matchMedia = mediaString => {
+        if (mediaString === '(prefers-reduced-motion)') {
+          return {matches: false}
+        }
+        return realMatchMedia(mediaString)
+      }
+    })
+
+    after(() => {
+      window.matchMedia = realMatchMedia
+    })
+
     it('uses defaults when no delays specified', function () {
       const typingEffectElement = document.createElement('typing-effect')
-      typingEffectElement.setAttribute('data-reduced-motion', false)
       document.body.append(typingEffectElement)
 
       assert.equal(typingEffectElement.characterDelay, 40)
@@ -101,16 +115,6 @@ describe('typing-effect', function () {
       assert.equal(window.matchMedia('(prefers-reduced-motion)').matches, true)
       assert.equal(typingEffectElement.characterDelay, 0)
       assert.equal(typingEffectElement.lineDelay, 0)
-    })
-
-    it('uses data-reduced-motion attribute to override window media query', function () {
-      const typingEffectElement = document.createElement('typing-effect')
-      typingEffectElement.setAttribute('data-reduced-motion', false)
-      document.body.append(typingEffectElement)
-
-      assert.equal(window.matchMedia('(prefers-reduced-motion)').matches, true)
-      assert.equal(typingEffectElement.characterDelay, 40)
-      assert.equal(typingEffectElement.lineDelay, 40)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,21 @@ describe('typing-effect', function () {
   })
 
   describe('a11y considerations', function () {
+    let realMatchMedia
+    before(() => {
+      realMatchMedia = window.matchMedia
+      window.matchMedia = mediaString => {
+        if (mediaString === '(prefers-reduced-motion)') {
+          return {matches: true}
+        }
+        return realMatchMedia(mediaString)
+      }
+    })
+
+    after(() => {
+      window.matchMedia = realMatchMedia
+    })
+
     it('sets delay to 0 when media query matches (prefers-reduced-motion)', function () {
       const typingEffectElement = document.createElement('typing-effect')
       document.body.append(typingEffectElement)

--- a/test/test.js
+++ b/test/test.js
@@ -70,8 +70,30 @@ describe('typing-effect', function () {
   describe('delay attributes', function () {
     it('uses defaults when no delays specified', function () {
       const typingEffectElement = document.createElement('typing-effect')
+      typingEffectElement.setAttribute('data-reduced-motion', false)
       document.body.append(typingEffectElement)
 
+      assert.equal(typingEffectElement.characterDelay, 40)
+      assert.equal(typingEffectElement.lineDelay, 40)
+    })
+  })
+
+  describe('a11y considerations', function () {
+    it('sets delay to 0 when media query matches (prefers-reduced-motion)', function () {
+      const typingEffectElement = document.createElement('typing-effect')
+      document.body.append(typingEffectElement)
+
+      assert.equal(window.matchMedia('(prefers-reduced-motion)').matches, true)
+      assert.equal(typingEffectElement.characterDelay, 0)
+      assert.equal(typingEffectElement.lineDelay, 0)
+    })
+
+    it('uses data-reduced-motion attribute to override window media query', function () {
+      const typingEffectElement = document.createElement('typing-effect')
+      typingEffectElement.setAttribute('data-reduced-motion', false)
+      document.body.append(typingEffectElement)
+
+      assert.equal(window.matchMedia('(prefers-reduced-motion)').matches, true)
       assert.equal(typingEffectElement.characterDelay, 40)
       assert.equal(typingEffectElement.lineDelay, 40)
     })


### PR DESCRIPTION
This PR adds functionality to the `<typing-effect>` component to handle the case where a user has a reduced motion setting. This change was originally brought on to accommodate a reduced-motion version of the new sign up page, but I figure that anywhere else this component is being used, we'll probably want the same behavior rather than having to apply it to every instance.

If reduced motion is preferred, the lines will append immediately to the content rather than being typed out with the character and line delay.

## Comparison
### Current
![join_next_animated](https://user-images.githubusercontent.com/5520141/119877718-fd886380-beee-11eb-8b6d-a214cf9d1941.gif)


### New
![join_next_reduced](https://user-images.githubusercontent.com/5520141/119878104-6243be00-beef-11eb-9a42-48da0dcef0c2.gif)
(refereshed a couple times bc it happens fast ⏩ )

## Testing
### Unit tests

I added a unit test to confirm that having the `window.matchMedia` returning `true` for reduced motion will set the delay to `0`, but I wasn't sure how to mock the `window` object in karma here. @koddsson - do you have any ideas where we could mock this value to be set within the test? (without adding another library / dependency). I tried overriding `global.window.matchMedia` but ran into an error saying I was "setting" a "getter".

### To manually test reduced motion
1. Go to System Preferences -> Accessibility -> Display -> CHECK "Reduce Motion"
2. Navigate to http://github.localhost/join_next
3. - [x] Confirm the stars in the background do not move
    - [x] Confirm the welcome message renders immediately, instead of typing out