### PR TITLE
Set CI to run on Pull Requests as well

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
I noticed in #1 that CI wasn't running. I think the action is just missing that we tell it to run on pull requests and pushes.