### PR TITLE
Fix Delay Attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ class TypingEffectElement extends HTMLElement {
   }
 
   get characterDelay(): number {
-    return Math.max(Math.min(0, Math.floor(Number(this.getAttribute('data-character-delay'))), 2_147_483_647)) || 40
+    return Math.max(0, Math.min(Math.floor(Number(this.getAttribute('data-character-delay'))), 2_147_483_647)) || 40
   }
 
   set characterDelay(value: number) {
@@ -51,7 +51,7 @@ class TypingEffectElement extends HTMLElement {
   }
 
   get lineDelay(): number {
-    return Math.max(Math.min(0, Math.floor(Number(this.getAttribute('data-line-delay'))), 2_147_483_647)) || 40
+    return Math.max(0, Math.min(Math.floor(Number(this.getAttribute('data-line-delay'))), 2_147_483_647)) || 40
   }
 
   set lineDelay(value: number) {

--- a/test/test.js
+++ b/test/test.js
@@ -75,6 +75,19 @@ describe('typing-effect', function () {
       assert.equal(typingEffectElement.characterDelay, 40)
       assert.equal(typingEffectElement.lineDelay, 40)
     })
+
+    it('uses specified delay attributes instead of using defaults', function () {
+      const characterDelay = 20
+      const lineDelay = 20
+      document.body.innerHTML = `
+        <typing-effect data-character-delay="${characterDelay}" data-line-delay="${lineDelay}">
+        </typing-effect>
+      `
+      const typingEffectElement = document.querySelector('typing-effect')
+
+      assert.equal(typingEffectElement.characterDelay, characterDelay)
+      assert.equal(typingEffectElement.lineDelay, lineDelay)
+    })
   })
 })
 


### PR DESCRIPTION
I found character delay and line delay aren't been set correctly even if I provided a valid value.
I think the bug is caused by a typo in the getter function, the minimum of `0`, `2_147_483_647`, `data-xxx-delay` is the only param of Math.max.
So I tried to fix the bug by moving the lower bound out of the calling of Math.min and it seems to work now. 
(Please forgive me for my poor English😥)